### PR TITLE
Add success job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,11 @@ jobs:
       - name: Cabal test
         run: |
           cabal test all --enable-tests --test-show-details=Always -fdev
+
+  success:
+    runs-on: ubuntu-latest
+    needs: build
+    name: All GHCs built successfully
+    steps:
+      - name: Success
+        run: echo "Success"


### PR DESCRIPTION
The idea is that I can then add just this job to the branch protection rules