### PR TITLE
Add (derived) instances of `Traversable` and `Foldable`.

### DIFF
--- a/free-listt.cabal
+++ b/free-listt.cabal
@@ -85,7 +85,7 @@ library
 
     default-extensions:
         ApplicativeDo,
-        DeriveFunctor,
+        DeriveTraversable,
         DerivingStrategies,
         DerivingVia,
         ImportQualifiedPost,

--- a/src/Control/Applicative/Trans/List.hs
+++ b/src/Control/Applicative/Trans/List.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveFoldable    #-}
-{-# LANGUAGE DeriveTraversable #-}
-
 -- | The applicative list transformer
 module Control.Applicative.Trans.List where
 

--- a/src/Control/Applicative/Trans/List.hs
+++ b/src/Control/Applicative/Trans/List.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveFoldable    #-}
+{-# LANGUAGE DeriveTraversable #-}
+
 -- | The applicative list transformer
 module Control.Applicative.Trans.List where
 
@@ -11,7 +14,7 @@ This is isomorphic to the "old" @ListT@ transformer.
 It is not a monad, but a lawful 'Applicative'.
 -}
 newtype ListT f a = ListT {runListT :: f [a]}
-  deriving (Functor)
+  deriving (Functor, Traversable, Foldable)
   deriving
     (Applicative, Alternative)
     via (Compose f [])


### PR DESCRIPTION
These were also in the old `Control.Monad.Trans.List`, can be quite useful, and GHC makes them automatically. So, probably not controversial?